### PR TITLE
chore(ci): sync Cargo version with release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,13 @@ jobs:
         shell: bash
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
+      - name: Update Cargo.toml with version number
+        shell: bash
+        run: |
+          sed --regexp-extended --in-place \
+            "s|^version = \"\\S+\"\|version = \"${VERSION}\"|" \
+            Cargo.toml
+
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown-oxide"
-version = "0.24.0"
+version = "0.25.1"
 edition = "2021"
 repository = "https://github.com/Feel-ix-343/markdown-oxide"
 


### PR DESCRIPTION
Hi :wave:, it's me, the guy who [requested the `--version` command line argument](https://github.com/Feel-ix-343/markdown-oxide/issues/177).

I'm looking at this project again and now would like to have up-to-date version information behind that flag.

This pull request:

* updates the version number in Cargo.toml
* adds a step to the deploy workflow that updates Cargo's version to matches the current git tag

so hopefully after this, it's something you won't ever need to think about again.

_An alternative approach:_ If you want to keep the version number up-to-date in Cargo.toml, we could alter this workflow step to _fail_ the workflow with a good error message, forcing you to update Cargo.toml before releasing. That might be more annoying though, so I opted for the "just update it" approach.